### PR TITLE
Add Streaming Frame Limit to Configuration

### DIFF
--- a/src/sd/sys/motion.conf
+++ b/src/sd/sys/motion.conf
@@ -157,6 +157,9 @@ stream_port 8081
 # Restrict stream connections to the localhost.
 stream_localhost off
 
+# Maximum frames per second for streaming.
+stream_maxrate 15
+
 # Set CORS properties for remote access
 stream_header_params "Access-Control-Allow-Origin=*, Cache-Control=\"no-cache\""
 


### PR DESCRIPTION
The default streaming frame rate is 1 fps. This commit increases that to a usable 15 fps and directs users to configure from there.